### PR TITLE
Make ApcCache flushAll method to clear both user & system cache types

### DIFF
--- a/lib/Adapter/Cache/ApcCache.php
+++ b/lib/Adapter/Cache/ApcCache.php
@@ -72,7 +72,7 @@ class ApcCache extends BaseCacheHandler
     public function flushAll()
     {
         if ($this->currentOnly) {
-            return apc_clear_cache('user');
+            return apc_clear_cache('user') && apc_clear_cache();
         }
 
         $result = true;


### PR DESCRIPTION
I've updated `flushAll()` method to make both `apc_clear_cache('user')` and `apc_clear_cache()` (system) cache types.
