### PR TITLE
fix typo instanciation redis client

### DIFF
--- a/lib/Adapter/Cache/PRedisCache.php
+++ b/lib/Adapter/Cache/PRedisCache.php
@@ -30,7 +30,7 @@ class PRedisCache extends BaseCacheHandler
      */
     public function __construct(array $parameters = array(), array $options = array())
     {
-        $this->prefix  = $parameters;
+        $this->parameters = $parameters;
         $this->options = $options;
     }
 


### PR DESCRIPTION
Hi, 
there is a typo in PRedis client instanciation, the parameters arary is not populated. 

Everything is fine a long as you don't need to change the default redis server ( localhost ).. .

With this, it's now ok.

thanks

Xavier
