### PR TITLE
fixed syntax error in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "predis/predis": "~0.8,<1.0",
         "doctrine/phpcr-odm": "~1.0",
         "jackalope/jackalope-doctrine-dbal": "~1.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "fabpot/php-cs-fixer": "~0.1|~1.0"
+        "symfony/phpunit-bridge": "~2.7 || ~3.0",
+        "fabpot/php-cs-fixer": "~0.1 || ~1.0"
     },
     "suggest": {
         "doctrine/orm": "ORM support",


### PR DESCRIPTION
On some composer installation this wrong logical OR (https://getcomposer.org/doc/articles/versions.md#range) results in broken builds.