### PR TITLE
Restrict test classes to the development autoload

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,0 +1,7 @@
+UPGRADE 2.0
+===========
+
+# Tests autoloading
+
+If you are reusing a test class from this project, you will no longer benefit from the autoload Composer generates.
+You should require the file manually or write your own autoloader instead.

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Sonata\\Cache\\Tests\\": "test/",
             "Sonata\\Cache\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sonata\\Cache\\Tests\\": "test/"
         }
     },
     "extra": {


### PR DESCRIPTION
I am targetting this branch, because there is a BC-break : people might extend our test classes, who knows?

## Changelog

```markdown
### Removed
- Test classes autoload is no longer available when not in development
```
## Subject

This PR restricts the autoload to test classes.
