### PR TITLE
Remove internal test classes from autoloader

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -5,3 +5,9 @@ UPGRADE 1.x
 
 The `lib` directory has been renamed to the more standard `src`.
 This should not change anything for users since this library is meant to be used with Composer autoloading only.
+
+### Tests
+
+All files under the ``Tests`` directory are now correctly handled as internal test classes. 
+You can't extend them anymore, because they are only loaded when running internal tests. 
+More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "predis/predis": "Install redis php"
     },
     "autoload": {
-        "psr-4": {
-            "Sonata\\Cache\\Tests\\": "test/",
-            "Sonata\\Cache\\": "src/"
-        }
+        "psr-4": { "Sonata\\Cache\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Sonata\\Cache\\Tests\\": "test/" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because test classes shouldn't be used by anybody. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/dev-kit/issues/179
Rebase of https://github.com/sonata-project/cache/pull/45

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- internal test classes are now excluded from the autoloader
```

## Subject

Tests for internal components shouldn't be loaded in production or extended by other bundles.

