### PR TITLE
Drop old php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require-dev": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "psr/log": "^1.0",
         "doctrine/orm": "^2.2",
         "predis/predis": "^0.8",


### PR DESCRIPTION
## Changelog

```markdown
### Removed
- PHP 5.3 through 5.5 support was removed
```

## Subject

This prepares the 2.0 release.

