### PR TITLE
Drop PHP < 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require-dev": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "psr/log": "^1.0",
         "doctrine/orm": "^2.2",
         "predis/predis": "^0.8",

--- a/src/Adapter/Cache/MemcachedCache.php
+++ b/src/Adapter/Cache/MemcachedCache.php
@@ -25,7 +25,7 @@ class MemcachedCache extends BaseCacheHandler
      * @param $prefix
      * @param array $servers
      */
-    public function __construct($prefix, array $servers)
+    public function __construct(string $prefix, array $servers)
     {
         $this->prefix = $prefix;
         $this->servers = $servers;
@@ -94,7 +94,7 @@ class MemcachedCache extends BaseCacheHandler
     /**
      * {@inheritdoc}
      */
-    private function getCollection()
+    private function getCollection(): \Memcached
     {
         if (!$this->collection) {
             $this->collection = new \Memcached();
@@ -110,7 +110,7 @@ class MemcachedCache extends BaseCacheHandler
     /**
      * {@inheritdoc}
      */
-    private function computeCacheKeys(array $keys)
+    private function computeCacheKeys(array $keys): string
     {
         ksort($keys);
 

--- a/src/Adapter/Cache/MongoCache.php
+++ b/src/Adapter/Cache/MongoCache.php
@@ -27,7 +27,7 @@ class MongoCache extends BaseCacheHandler
      * @param $database
      * @param $collection
      */
-    public function __construct(array $servers, $database, $collection)
+    public function __construct(array $servers, string $database, string $collection)
     {
         $this->servers = $servers;
         $this->databaseName = $database;
@@ -118,7 +118,7 @@ class MongoCache extends BaseCacheHandler
     /**
      * @return \MongoCollection
      */
-    private function getCollection()
+    private function getCollection(): \MongoCollection
     {
         if (!$this->collection) {
             $class = self::getMongoClass();

--- a/src/Adapter/Cache/OpCodeCache.php
+++ b/src/Adapter/Cache/OpCodeCache.php
@@ -59,7 +59,7 @@ class OpCodeCache extends BaseCacheHandler
      * @param array  $servers An array of servers
      * @param array  $timeout An array of timeout options
      */
-    public function __construct($url, $prefix, array $servers, array $timeout = array())
+    public function __construct(string $url, string $prefix, array $servers, array $timeout = array())
     {
         $this->url = $url;
         $this->prefix = $prefix;

--- a/src/Adapter/Cache/PRedisCache.php
+++ b/src/Adapter/Cache/PRedisCache.php
@@ -143,7 +143,7 @@ class PRedisCache extends BaseCacheHandler
     /**
      * {@inheritdoc}
      */
-    private function computeCacheKeys(array $keys)
+    private function computeCacheKeys(array $keys): string
     {
         ksort($keys);
 

--- a/src/Adapter/Counter/ApcCounter.php
+++ b/src/Adapter/Counter/ApcCounter.php
@@ -28,7 +28,7 @@ class ApcCounter extends BaseCounter
      *
      * @param string $prefix A prefix to avoid clash between instances
      */
-    public function __construct($prefix)
+    public function __construct(string $prefix)
     {
         $this->prefix = $prefix;
     }

--- a/src/Adapter/Counter/MemcachedCounter.php
+++ b/src/Adapter/Counter/MemcachedCounter.php
@@ -25,7 +25,7 @@ class MemcachedCounter extends BaseCounter
      * @param $prefix
      * @param array $servers
      */
-    public function __construct($prefix, array $servers)
+    public function __construct(string $prefix, array $servers)
     {
         $this->prefix = $prefix;
         $this->servers = $servers;
@@ -76,7 +76,7 @@ class MemcachedCounter extends BaseCounter
     /**
      * {@inheritdoc}
      */
-    private function getCollection()
+    private function getCollection(): \Memcached
     {
         if (!$this->collection) {
             $this->collection = new \Memcached();

--- a/src/Adapter/Counter/MongoCounter.php
+++ b/src/Adapter/Counter/MongoCounter.php
@@ -28,7 +28,7 @@ class MongoCounter extends BaseCounter
      * @param $database
      * @param $collection
      */
-    public function __construct(array $servers, $database, $collection)
+    public function __construct(array $servers, string $database, string $collection)
     {
         $this->servers = $servers;
         $this->databaseName = $database;
@@ -97,7 +97,7 @@ class MongoCounter extends BaseCounter
     /**
      * @return \MongoCollection
      */
-    private function getCollection()
+    private function getCollection(): \MongoCollection
     {
         if (!$this->collection) {
             $class = MongoCache::getMongoClass();

--- a/src/Adapter/Counter/PRedisCounter.php
+++ b/src/Adapter/Counter/PRedisCounter.php
@@ -85,7 +85,7 @@ class PRedisCounter extends BaseCounter
     /**
      * @return Client
      */
-    private function getClient()
+    private function getClient(): Client
     {
         if (!$this->client) {
             $this->client = new Client($this->parameters, $this->options);

--- a/src/CacheElement.php
+++ b/src/CacheElement.php
@@ -52,7 +52,7 @@ final class CacheElement
      * @param int   $ttl            A time to live, default 86400 seconds (CacheElement::DAY)
      * @param array $contextualKeys An array of contextual keys
      */
-    public function __construct(array $keys, $data, $ttl = self::DAY, array $contextualKeys = array())
+    public function __construct(array $keys, $data, int $ttl = self::DAY, array $contextualKeys = array())
     {
         $this->createdAt = new \DateTime();
         $this->keys = $keys;

--- a/src/Counter.php
+++ b/src/Counter.php
@@ -21,7 +21,7 @@ final class Counter
      * @param string $name
      * @param mixed  $value
      */
-    private function __construct($name, $value = 0)
+    private function __construct(string $name, $value = 0)
     {
         if (!is_int($value)) {
             throw new \RuntimeException('The value is not numeric for the counter');

--- a/src/Invalidation/DoctrineORMListener.php
+++ b/src/Invalidation/DoctrineORMListener.php
@@ -27,7 +27,7 @@ class DoctrineORMListener implements EventSubscriber
      * @param ModelCollectionIdentifiers $collectionIdentifiers
      * @param array                      $caches
      */
-    public function __construct(ModelCollectionIdentifiers $collectionIdentifiers, $caches)
+    public function __construct(ModelCollectionIdentifiers $collectionIdentifiers, array $caches)
     {
         $this->collectionIdentifiers = $collectionIdentifiers;
 

--- a/src/Invalidation/DoctrinePHPCRODMListener.php
+++ b/src/Invalidation/DoctrinePHPCRODMListener.php
@@ -27,7 +27,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
      * @param ModelCollectionIdentifiers $collectionIdentifiers
      * @param array                      $caches
      */
-    public function __construct(ModelCollectionIdentifiers $collectionIdentifiers, $caches)
+    public function __construct(ModelCollectionIdentifiers $collectionIdentifiers, array $caches)
     {
         $this->collectionIdentifiers = $collectionIdentifiers;
 


### PR DESCRIPTION
I am targetting this branch, because this is considered major.

Refs https://github.com/sonata-project/dev-kit/issues/216

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for PHP < 7 has been removed
```

private functions and constructors have been type hinted