### PR TITLE
Drop old versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     "require-dev": {
         "php": "^7.0",
         "psr/log": "^1.0",
-        "doctrine/orm": "^2.2",
-        "predis/predis": "^1.0",
-        "doctrine/phpcr-odm": "^1.0",
-        "jackalope/jackalope-doctrine-dbal": "^1.0",
-        "symfony/phpunit-bridge": "^3.0",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
+        "doctrine/orm": "^2.5",
+        "predis/predis": "^1.1",
+        "doctrine/phpcr-odm": "^1.4",
+        "jackalope/jackalope-doctrine-dbal": "^1.2",
+        "symfony/phpunit-bridge": "^3.2",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
     },
     "suggest": {
         "doctrine/orm": "ORM support",
@@ -34,6 +34,11 @@
     },
     "autoload-dev": {
         "psr-4": { "Sonata\\Cache\\Tests\\": "test/" }
+    },
+    "conflicts": {
+        "doctrine/orm": "<2.5",
+        "predis/predis": "<1.1",
+        "doctrine/phpcr-odm": "<1.4"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "php": "^7.0",
         "psr/log": "^1.0",
         "doctrine/orm": "^2.2",
-        "predis/predis": "^0.8 || ^1.0",
+        "predis/predis": "^1.0",
         "doctrine/phpcr-odm": "^1.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {


### PR DESCRIPTION
Only test dependencies were dropped, so this is pedantic.