### PR TITLE
Restrict visibility of properties in final classes

### DIFF
--- a/src/CacheElement.php
+++ b/src/CacheElement.php
@@ -22,27 +22,27 @@ final class CacheElement
     /**
      * @var int
      */
-    protected $ttl;
+    private $ttl;
 
     /**
      * @var array
      */
-    protected $keys = array();
+    private $keys = array();
 
     /**
      * @var mixed
      */
-    protected $data;
+    private $data;
 
     /**
      * @var \DateTime
      */
-    protected $createdAt;
+    private $createdAt;
 
     /**
      * @var array
      */
-    protected $contextualKeys = array();
+    private $contextualKeys = array();
 
     /**
      * Constructor.

--- a/src/Counter.php
+++ b/src/Counter.php
@@ -13,9 +13,9 @@ namespace Sonata\Cache;
 
 final class Counter
 {
-    protected $name;
+    private $name;
 
-    protected $value;
+    private $value;
 
     /**
      * @param string $name


### PR DESCRIPTION
These classes are final. Having protected things in them does not make
any sense.
