### PR TITLE
Remove void return type.

### DIFF
--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -46,7 +46,7 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function addCacheService(string $name, CacheAdapterInterface $cacheManager): void
+    public function addCacheService(string $name, CacheAdapterInterface $cacheManager)
     {
         $this->cacheServices[$name] = $cacheManager;
     }

--- a/src/CacheManagerInterface.php
+++ b/src/CacheManagerInterface.php
@@ -21,7 +21,7 @@ interface CacheManagerInterface
      * @param string                $name         A cache name
      * @param CacheAdapterInterface $cacheManager A cache service
      */
-    public function addCacheService(string $name, CacheAdapterInterface $cacheManager): void;
+    public function addCacheService(string $name, CacheAdapterInterface $cacheManager);
 
     /**
      * Gets a cache service by a given name.


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Compatibility with PHP ~7.0.0 (void return type).
```

## Subject

I missed the fact that void return type is a `PHP >= 7.1`
feature when I suggested to add them on #65.

Reference: [PHP RFC: Void Return Type](https://wiki.php.net/rfc/void_return_type)
