### PR TITLE
Reordered composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
-        "predis/predis": "^1.1",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
-        "symfony/phpunit-bridge": "^3.2",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
+        "predis/predis": "^1.1",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1",
+        "symfony/phpunit-bridge": "^3.2"
     },
     "suggest": {
         "doctrine/orm": "ORM support",
@@ -43,8 +43,11 @@
     },
     "conflicts": {
         "doctrine/orm": "<2.5",
-        "predis/predis": "<1.1",
-        "doctrine/phpcr-odm": "<1.4"
+        "doctrine/phpcr-odm": "<1.4",
+        "predis/predis": "<1.1"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
             "name": "Thomas Rabaix",
             "email": "thomas.rabaix@gmail.com",
             "homepage": "https://sonata-project.org/"
+        },
+        {
+            "name": "Sonata Community",
+            "homepage": "https://github.com/sonata-project/cache/contributors"
         }
     ],
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,11 @@
             "homepage": "https://github.com/sonata-project/cache/contributors"
         }
     ],
+    "require": {
+        "php": "^7.1",
+        "psr/log": "^1.0"
+    },
     "require-dev": {
-        "php": "^7.0",
-        "psr/log": "^1.0",
         "doctrine/orm": "^2.5",
         "predis/predis": "^1.1",
         "doctrine/phpcr-odm": "^1.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./test/bootstrap.php" colors="true">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="test/bootstrap.php"
+>
     <testsuites>
         <testsuite name="Cache Test Suite">
-            <directory suffix="Test.php">./test/</directory>
+            <directory>./test</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory suffix=".php">./src/Cache/</directory>
+            <directory>./</directory>
+            <exclude>
+                <directory>./test/</directory>
+            </exclude>
         </whitelist>
     </filter>
+
+    <php>
+        <ini name="precision" value="8"/>
+    </php>
+
 </phpunit>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/cache/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this applies for this new release.
Also this could be done for 1.x so maybe we need to move this PR to 1.x branch first.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Add PHP and Psr/log as required dependencies
```
## Subject

<!-- Describe your Pull Request content here -->
At first I wanted to update PHP from 7.0 to 7.1, then I saw the other things:

* Add Sonata contributors as authors
* Move PHP to required section
* Move psr/log to required section (not sure about this one)
* Sort composer packages