### PR TITLE
Add void typehint back

### DIFF
--- a/src/Adapter/Cache/OpCodeCache.php
+++ b/src/Adapter/Cache/OpCodeCache.php
@@ -78,7 +78,7 @@ class OpCodeCache extends BaseCacheHandler
     /**
      * @param bool $bool
      */
-    public function setCurrentOnly($bool)
+    public function setCurrentOnly($bool): void
     {
         $this->currentOnly = $bool;
     }

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -82,7 +82,7 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function invalidate(array $keys)
+    public function invalidate(array $keys): void
     {
         $this->cacheInvalidation->invalidate($this->getCacheServices(), $keys);
     }
@@ -90,7 +90,7 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function setRecorder(Recorder $recorder)
+    public function setRecorder(Recorder $recorder): void
     {
         $this->recorder = $recorder;
     }

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -46,7 +46,7 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function addCacheService(string $name, CacheAdapterInterface $cacheManager)
+    public function addCacheService(string $name, CacheAdapterInterface $cacheManager): void
     {
         $this->cacheServices[$name] = $cacheManager;
     }

--- a/src/CacheManagerInterface.php
+++ b/src/CacheManagerInterface.php
@@ -53,14 +53,14 @@ interface CacheManagerInterface
      *
      * @param array $keys
      */
-    public function invalidate(array $keys);
+    public function invalidate(array $keys): void;
 
     /**
      * Sets the recorder.
      *
      * @param Recorder $recorder
      */
-    public function setRecorder(Recorder $recorder);
+    public function setRecorder(Recorder $recorder): void;
 
     /**
      * Gets the recorder.

--- a/src/CacheManagerInterface.php
+++ b/src/CacheManagerInterface.php
@@ -21,7 +21,7 @@ interface CacheManagerInterface
      * @param string                $name         A cache name
      * @param CacheAdapterInterface $cacheManager A cache service
      */
-    public function addCacheService(string $name, CacheAdapterInterface $cacheManager);
+    public function addCacheService(string $name, CacheAdapterInterface $cacheManager): void;
 
     /**
      * Gets a cache service by a given name.

--- a/src/Invalidation/DoctrineORMListener.php
+++ b/src/Invalidation/DoctrineORMListener.php
@@ -50,7 +50,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -58,7 +58,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -66,7 +66,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * @param CacheAdapterInterface $cache
      */
-    public function addCache(CacheAdapterInterface $cache)
+    public function addCache(CacheAdapterInterface $cache): void
     {
         if (!$cache->isContextual()) {
             return;
@@ -78,7 +78,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    protected function flush(LifecycleEventArgs $args)
+    protected function flush(LifecycleEventArgs $args): void
     {
         $identifier = $this->collectionIdentifiers->getIdentifier($args->getEntity());
 

--- a/src/Invalidation/DoctrineORMListener.php
+++ b/src/Invalidation/DoctrineORMListener.php
@@ -50,7 +50,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preRemove(LifecycleEventArgs $args): void
+    public function preRemove(LifecycleEventArgs $args)
     {
         $this->flush($args);
     }
@@ -58,7 +58,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preUpdate(LifecycleEventArgs $args): void
+    public function preUpdate(LifecycleEventArgs $args)
     {
         $this->flush($args);
     }
@@ -66,7 +66,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * @param CacheAdapterInterface $cache
      */
-    public function addCache(CacheAdapterInterface $cache): void
+    public function addCache(CacheAdapterInterface $cache)
     {
         if (!$cache->isContextual()) {
             return;
@@ -78,7 +78,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    protected function flush(LifecycleEventArgs $args): void
+    protected function flush(LifecycleEventArgs $args)
     {
         $identifier = $this->collectionIdentifiers->getIdentifier($args->getEntity());
 

--- a/src/Invalidation/DoctrinePHPCRODMListener.php
+++ b/src/Invalidation/DoctrinePHPCRODMListener.php
@@ -50,7 +50,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -58,7 +58,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -66,7 +66,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function addCache(CacheAdapterInterface $cache)
+    public function addCache(CacheAdapterInterface $cache): void
     {
         if (!$cache->isContextual()) {
             return;
@@ -78,7 +78,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    protected function flush(LifecycleEventArgs $args)
+    protected function flush(LifecycleEventArgs $args): void
     {
         $identifier = $this->collectionIdentifiers->getIdentifier($args->getDocument());
 

--- a/src/Invalidation/ModelCollectionIdentifiers.php
+++ b/src/Invalidation/ModelCollectionIdentifiers.php
@@ -29,7 +29,7 @@ class ModelCollectionIdentifiers
      * @param string $class
      * @param mixed  $identifier
      */
-    public function addClass(string $class, $identifier)
+    public function addClass(string $class, $identifier): void
     {
         $this->classes[$class] = $identifier;
     }

--- a/src/Invalidation/Recorder.php
+++ b/src/Invalidation/Recorder.php
@@ -31,7 +31,7 @@ class Recorder
     /**
      * @param $object
      */
-    public function add($object)
+    public function add($object): void
     {
         $class = get_class($object);
 
@@ -53,7 +53,7 @@ class Recorder
     /**
      * Add a new elements into the stack.
      */
-    public function push()
+    public function push(): void
     {
         $this->stack[$this->current + 1] = $this->stack[$this->current];
 
@@ -80,7 +80,7 @@ class Recorder
         return $value;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->current = 0;
         $this->stack = array();


### PR DESCRIPTION
I am targeting this branch, because this is a BC break.

## Changelog

```markdown
### Changed
- Add void return typehints.
```

## Subject

Since we dropped PHP 7.0 support on master, we can now add void return typehints back!
