### PR TITLE
Added logger and php as a required deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,16 @@
             "homepage": "https://sonata-project.org/"
         }
     ],
+    "require": {
+        "php": "^7.1",
+        "psr/log": "^1.0"
+    },
     "require-dev": {
-        "php": "^5.3 || ^7.0",
-        "psr/log": "^1.0",
         "doctrine/orm": "^2.2",
         "predis/predis": "^0.8",
         "doctrine/phpcr-odm": "^1.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^3.3",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added php as a required dependency
- Added PSR logger as a required dependency
```

### Subject
The PHP dependency was missing in the composer definition, also it is obviously a PHP programm 🤣 . 
The PSR logger is used inside the [SimpleCacheInvalidation](https://github.com/sonata-project/cache/blob/1.x/src/Invalidation/SimpleCacheInvalidation.php#L14) class.
