### PR TITLE
php 7.1 specific type hinting

### DIFF
--- a/src/Invalidation/DoctrineORMListener.php
+++ b/src/Invalidation/DoctrineORMListener.php
@@ -50,7 +50,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -58,7 +58,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $this->flush($args);
     }
@@ -66,7 +66,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * @param CacheAdapterInterface $cache
      */
-    public function addCache(CacheAdapterInterface $cache)
+    public function addCache(CacheAdapterInterface $cache): void
     {
         if (!$cache->isContextual()) {
             return;
@@ -78,7 +78,7 @@ class DoctrineORMListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    protected function flush(LifecycleEventArgs $args)
+    protected function flush(LifecycleEventArgs $args): void
     {
         $identifier = $this->collectionIdentifiers->getIdentifier($args->getEntity());
 

--- a/src/Invalidation/SimpleCacheInvalidation.php
+++ b/src/Invalidation/SimpleCacheInvalidation.php
@@ -24,7 +24,7 @@ class SimpleCacheInvalidation implements InvalidationInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/tests/Adapter/Cache/ApcCacheTest.php
+++ b/tests/Adapter/Cache/ApcCacheTest.php
@@ -15,7 +15,7 @@ use Sonata\Cache\Adapter\Cache\ApcCache;
 
 class ApcCacheTest extends BaseTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!function_exists('apc_store')) {
             $this->markTestSkipped('APC is not installed');

--- a/tests/Adapter/Cache/BaseTest.php
+++ b/tests/Adapter/Cache/BaseTest.php
@@ -20,7 +20,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      */
     abstract public function getCache();
 
-    public function testBasicOperations()
+    public function testBasicOperations(): void
     {
         // init cache
         $cache = $this->getCache();
@@ -45,7 +45,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($cache->has(['id' => 7]));
     }
 
-    public function testNonExistantCache()
+    public function testNonExistantCache(): void
     {
         $cache = $this->getCache();
 
@@ -55,7 +55,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($cacheElement->isExpired());
     }
 
-    public function testExpired()
+    public function testExpired(): void
     {
         $cache = $this->getCache();
 

--- a/tests/Adapter/Cache/MemcachedCacheTest.php
+++ b/tests/Adapter/Cache/MemcachedCacheTest.php
@@ -15,7 +15,7 @@ use Sonata\Cache\Adapter\Cache\MemcachedCache;
 
 class MemcachedCacheTest extends BaseTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Memcached', true)) {
             $this->markTestSkipped('Memcached is not installed');

--- a/tests/Adapter/Cache/MongoCacheTest.php
+++ b/tests/Adapter/Cache/MongoCacheTest.php
@@ -15,7 +15,7 @@ use Sonata\Cache\Adapter\Cache\MongoCache;
 
 class MongoCacheTest extends BaseTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $class = MongoCache::getMongoClass();
 

--- a/tests/Adapter/Cache/NoopCacheTest.php
+++ b/tests/Adapter/Cache/NoopCacheTest.php
@@ -15,7 +15,7 @@ use Sonata\Cache\Adapter\Cache\NoopCache;
 
 class NoopCacheTest extends \PHPUnit_Framework_TestCase
 {
-    public function testNoopCache()
+    public function testNoopCache(): void
     {
         $cache = new NoopCache();
 
@@ -28,7 +28,7 @@ class NoopCacheTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function getGet()
+    public function getGet(): void
     {
         $cache = new NoopCache();
         $cache->get([]);

--- a/tests/Adapter/Cache/OpCodeCacheTest.php
+++ b/tests/Adapter/Cache/OpCodeCacheTest.php
@@ -20,13 +20,13 @@ class OpCodeCacheTest extends \PHPUnit_Framework_TestCase
      */
     protected $cache;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cache = new OpCodeCache('http://localhost', 'prefix_', [], []);
         $this->cache->setCurrentOnly(true);
     }
 
-    public function testFlushAll()
+    public function testFlushAll(): void
     {
         $res = $this->cache->flushAll();
         $this->assertTrue($res);

--- a/tests/Adapter/Cache/PRedisCacheTest.php
+++ b/tests/Adapter/Cache/PRedisCacheTest.php
@@ -16,7 +16,7 @@ use Sonata\Cache\Adapter\Cache\PRedisCache;
 
 class PRedisCacheTest extends BaseTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Predis\Client', true)) {
             $this->markTestSkipped('PRedis is not installed');
@@ -59,7 +59,7 @@ class PRedisCacheTest extends BaseTest
     /**
      * Tests the flushAll method when connection is a single one.
      */
-    public function testFlushAllForSingleConnection()
+    public function testFlushAllForSingleConnection(): void
     {
         $cache = $this->getMockBuilder('Sonata\Cache\Adapter\Cache\PRedisCache')
             ->setMethods(['getClient'])
@@ -81,7 +81,7 @@ class PRedisCacheTest extends BaseTest
     /**
      * Tests the flushAll method when connection is a cluster one.
      */
-    public function testFlushAllForClusterConnection()
+    public function testFlushAllForClusterConnection(): void
     {
         $cache = $this->getMockBuilder('Sonata\Cache\Adapter\Cache\PRedisCache')
             ->setMethods(['getClient'])

--- a/tests/Adapter/Counter/ApcCounterTest.php
+++ b/tests/Adapter/Counter/ApcCounterTest.php
@@ -16,7 +16,7 @@ use Sonata\Cache\Counter;
 
 class ApcCounterTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!function_exists('apc_store')) {
             $this->markTestSkipped('APC is not installed');
@@ -29,7 +29,7 @@ class ApcCounterTest extends \PHPUnit_Framework_TestCase
         apc_clear_cache('user');
     }
 
-    public function testCounterBackend()
+    public function testCounterBackend(): void
     {
         $backend = new ApcCounter('prefix');
 
@@ -57,7 +57,7 @@ class ApcCounterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(-10, $counter->getValue());
     }
 
-    public function testNonExistantKey()
+    public function testNonExistantKey(): void
     {
         $backend = new ApcCounter('prefix');
 

--- a/tests/Adapter/Counter/MemcachedCounterTest.php
+++ b/tests/Adapter/Counter/MemcachedCounterTest.php
@@ -16,7 +16,7 @@ use Sonata\Cache\Counter;
 
 class MemcachedCounterTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Memcached', true)) {
             $this->markTestSkipped('Memcached is not installed');
@@ -41,7 +41,7 @@ class MemcachedCounterTest extends \PHPUnit_Framework_TestCase
         $memcached->fetchAll();
     }
 
-    public function testCounterBackend()
+    public function testCounterBackend(): void
     {
         $backend = new MemcachedCounter('prefix', [
             ['host' => '127.0.0.1', 'port' => 11211, 'weight' => 100],
@@ -74,7 +74,7 @@ class MemcachedCounterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $counter->getValue());
     }
 
-    public function testNonExistantKey()
+    public function testNonExistantKey(): void
     {
         $backend = new MemcachedCounter('prefix', [
             ['host' => '127.0.0.1', 'port' => 11211, 'weight' => 100],

--- a/tests/Adapter/Counter/MongoCounterTest.php
+++ b/tests/Adapter/Counter/MongoCounterTest.php
@@ -17,7 +17,7 @@ use Sonata\Cache\Counter;
 
 class MongoCounterTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $class = MongoCache::getMongoClass();
 
@@ -46,7 +46,7 @@ class MongoCounterTest extends \PHPUnit_Framework_TestCase
             ->remove([]);
     }
 
-    public function testCounterBackend()
+    public function testCounterBackend(): void
     {
         $backend = new MongoCounter(['127.0.0.1:27017'], 'sonata_counter_test', 'counter');
 
@@ -75,7 +75,7 @@ class MongoCounterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(-10, $counter->getValue());
     }
 
-    public function testNonExistantKey()
+    public function testNonExistantKey(): void
     {
         $backend = new MongoCounter(['127.0.0.1:27017'], 'sonata_counter_test', 'counter');
 

--- a/tests/Adapter/Counter/PRedisCounterTest.php
+++ b/tests/Adapter/Counter/PRedisCounterTest.php
@@ -23,7 +23,7 @@ class PRedisCounterTest extends \PHPUnit_Framework_TestCase
         'database' => 42,
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Predis\Client', true)) {
             $this->markTestSkipped('PRedis is not installed');
@@ -47,7 +47,7 @@ class PRedisCounterTest extends \PHPUnit_Framework_TestCase
         $client->flushdb();
     }
 
-    public function testCounterBackend()
+    public function testCounterBackend(): void
     {
         $backend = new PRedisCounter($this->parameters);
 
@@ -76,7 +76,7 @@ class PRedisCounterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(-10, $counter->getValue());
     }
 
-    public function testNonExistantKey()
+    public function testNonExistantKey(): void
     {
         $backend = new PRedisCounter($this->parameters);
 

--- a/tests/CacheElementTest.php
+++ b/tests/CacheElementTest.php
@@ -15,7 +15,7 @@ use Sonata\Cache\CacheElement;
 
 class CacheElementTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCache()
+    public function testCache(): void
     {
         $cacheKeys = [
           'block_id' => '1',
@@ -35,7 +35,7 @@ class CacheElementTest extends \PHPUnit_Framework_TestCase
         $cache->getExpirationDate();
     }
 
-    public function testContextual()
+    public function testContextual(): void
     {
         $cacheKeys = [
           'block_id' => '1',

--- a/tests/CounterTest.php
+++ b/tests/CounterTest.php
@@ -18,12 +18,12 @@ class CounterTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \TypeError
      */
-    public function testInvalidValue()
+    public function testInvalidValue(): void
     {
         Counter::create('value', 'data');
     }
 
-    public function testClass()
+    public function testClass(): void
     {
         $counter = Counter::create('mycounter', 42);
 

--- a/tests/Invalidation/DoctrineORMListenerTest.php
+++ b/tests/Invalidation/DoctrineORMListenerTest.php
@@ -24,7 +24,7 @@ class DoctrineORMListenerTest_Model
 
 class DoctrineORMListenerTest extends \PHPUnit_Framework_TestCase
 {
-    public function test()
+    public function test(): void
     {
         $collection = new ModelCollectionIdentifiers();
 

--- a/tests/Invalidation/ModelCollectionIdentifiersTest.php
+++ b/tests/Invalidation/ModelCollectionIdentifiersTest.php
@@ -39,7 +39,7 @@ class Model_3 extends Model_2
 
 class CacheElementTest extends \PHPUnit_Framework_TestCase
 {
-    public function test()
+    public function test(): void
     {
         $collection = new ModelCollectionIdentifiers([
             'Sonata\Cache\Tests\Invalidation\Model_3' => 'getId',

--- a/tests/Invalidation/RecorderTest.php
+++ b/tests/Invalidation/RecorderTest.php
@@ -40,7 +40,7 @@ class Recorder_Model_3
 
 class RecorderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testRecorder()
+    public function testRecorder(): void
     {
         $collection = new ModelCollectionIdentifiers([
             'Sonata\Cache\Tests\Invalidation\Recorder_Model_1' => 'getCacheIdentifier',

--- a/tests/Invalidation/SimpleCacheInvalidationTest.php
+++ b/tests/Invalidation/SimpleCacheInvalidationTest.php
@@ -19,7 +19,7 @@ class SimpleCacheInvalidationTest_Cache
 
 class SimpleCacheInvalidationTest extends \PHPUnit_Framework_TestCase
 {
-    public function testInvalidate()
+    public function testInvalidate(): void
     {
         $cacheInvalidation = new SimpleCacheInvalidation();
 
@@ -34,7 +34,7 @@ class SimpleCacheInvalidationTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testWithoutLogger()
+    public function testWithoutLogger(): void
     {
         $cacheInvalidation = new SimpleCacheInvalidation();
 
@@ -46,7 +46,7 @@ class SimpleCacheInvalidationTest extends \PHPUnit_Framework_TestCase
         $cacheInvalidation->invalidate($caches, ['page_id' => 1]);
     }
 
-    public function testWithLogger()
+    public function testWithLogger(): void
     {
         $logger = $this->getMock('Psr\Log\LoggerInterface', [], [], '', false);
         $logger->expects($this->exactly(1))->method('info');
@@ -65,7 +65,7 @@ class SimpleCacheInvalidationTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testInvalidCacheHandle()
+    public function testInvalidCacheHandle(): void
     {
         $cacheInvalidation = new SimpleCacheInvalidation();
 


### PR DESCRIPTION
I am targeting this branch, because this is major.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- php 7.1-specific type hinting

```
## Subject

This adds `void` return type and `?` marker to optional arguments.
