### PR TITLE
Fixing interface conformation issues for Memcached Adapter

### DIFF
--- a/src/Adapter/Cache/MemcachedCache.php
+++ b/src/Adapter/Cache/MemcachedCache.php
@@ -12,6 +12,7 @@
 namespace Sonata\Cache\Adapter\Cache;
 
 use Sonata\Cache\CacheElement;
+use Sonata\Cache\CacheElementInterface;
 
 class MemcachedCache extends BaseCacheHandler
 {
@@ -78,7 +79,7 @@ class MemcachedCache extends BaseCacheHandler
     /**
      * {@inheritdoc}
      */
-    public function get(array $keys)
+    public function get(array $keys): CacheElementInterface
     {
         return $this->handleGet($keys, $this->getCollection()->get($this->computeCacheKeys($keys)));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/cache/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #100

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added return type `CacheAdapterInterface` to `MemcachedCache#get(array $keys)`

### Fixed
The get method of Memcahed Adapter

## Subject

Fixing interface conformation issues for Memcached Adapter
