### PR TITLE
use the right method to get the object of the lifecycle event arguments

### DIFF
--- a/src/Invalidation/DoctrinePHPCRODMListener.php
+++ b/src/Invalidation/DoctrinePHPCRODMListener.php
@@ -80,14 +80,14 @@ class DoctrinePHPCRODMListener implements EventSubscriber
      */
     protected function flush(LifecycleEventArgs $args): void
     {
-        $identifier = $this->collectionIdentifiers->getIdentifier($args->getDocument());
+        $identifier = $this->collectionIdentifiers->getIdentifier($args->getObject());
 
         if (false === $identifier) {
             return;
         }
 
         $parameters = [
-            ClassUtils::getClass($args->getDocument()) => $identifier,
+            ClassUtils::getClass($args->getObject()) => $identifier,
         ];
 
         foreach ($this->caches as $cache) {

--- a/tests/Invalidation/DoctrinePHPCRODMListenerTest.php
+++ b/tests/Invalidation/DoctrinePHPCRODMListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Cache\Tests\Cache\Invalidation;
+
+use Sonata\Cache\Invalidation\DoctrinePHPCRODMListener;
+use Sonata\Cache\Invalidation\ModelCollectionIdentifiers;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Sonata\Cache\CacheAdapterInterface;
+
+class DoctrinePHPCRODMListenerTest_Model
+{
+    public function getCacheIdentifier()
+    {
+        return '1';
+    }
+}
+
+class DoctrinePHPCRODMListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function test(): void
+    {
+        $collection = new ModelCollectionIdentifiers();
+
+        $listener = new DoctrinePHPCRODMListener($collection, []);
+
+        $event = $this->createMock(LifecycleEventArgs::class, [], [], '', false);
+        $event->expects($this->exactly(4))
+            ->method('getObject')
+            ->will($this->returnValue(new DoctrinePHPCRODMListenerTest_Model()));
+
+        $cache = $this->createMock(CacheAdapterInterface::class);
+        $cache->expects($this->exactly(2))
+            ->method('flush')
+            ->will($this->returnValue(true));
+
+        $cache->expects($this->exactly(1))
+            ->method('isContextual')
+            ->will($this->returnValue(true));
+
+        $listener->addCache($cache);
+
+        $listener->preUpdate($event);
+        $listener->preRemove($event);
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because its a bugfix.

## Changelog
```markdown
### Fixed
- PHPCR-ODM cache listener: use correct method to get object from event lifecycle arguments
```

## Subject

In symfony-cmf we see an exception with this invalidator: https://github.com/symfony-cmf/cmf-sandbox/pull/398

I don't know why we did not see it before (likely we were not using this) and i think this listener never actually worked. There is no test for it unfortunately.