### PR TITLE
fix wrong predis cluster namespace in predis cache adapter

### DIFF
--- a/src/Adapter/Cache/PRedisCache.php
+++ b/src/Adapter/Cache/PRedisCache.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Cache\Adapter\Cache;
 
 use Predis\Client;
-use Predis\Connection\PredisCluster;
+use Predis\Connection\Aggregate\PredisCluster;
 use Sonata\Cache\CacheElement;
 use Sonata\Cache\CacheElementInterface;
 

--- a/tests/Adapter/Cache/PRedisCacheTest.php
+++ b/tests/Adapter/Cache/PRedisCacheTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Cache\Tests\Adapter\Cache;
 
 use Predis\Client;
+use Predis\Connection\Aggregate\PredisCluster;
 use Sonata\Cache\Adapter\Cache\PRedisCache;
 
 class PRedisCacheTest extends BaseTest
@@ -91,7 +92,7 @@ class PRedisCacheTest extends BaseTest
 
         $command = $this->createMock('Predis\Command\CommandInterface');
 
-        $connection = $this->createMock('Predis\Connection\PredisCluster');
+        $connection = $this->createMock(PredisCluster::class);
         $connection->expects($this->exactly(5))->method('executeCommandOnNodes')->with($this->equalTo($command))->will($this->onConsecutiveCalls([false], [true], [false, true], [true, false], [true, true]));
 
         $client = $this->createMock('Predis\ClientInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/cache/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the `PredisCluster` namespace in `PRedisCacheAdapter`
```

## Subject
Predis caches could not be flushed on clusters because the PRedisCluser namespace was wrong.
