### PR TITLE
add PSR6 cache adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "homepage": "https://github.com/sonata-project/cache",
     "require": {
         "php": "^7.3 || ^8.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
@@ -36,6 +37,7 @@
         "phpunit/phpunit": "^9.5",
         "predis/predis": "^1.1",
         "psalm/plugin-phpunit": "^0.16.1",
+        "symfony/cache": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",
         "vimeo/psalm": "^4.18"
     },
@@ -62,6 +64,10 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": true
+        },
         "sort-packages": true
     },
     "extra": {

--- a/src/Adapter/Cache/MemcachedCache.php
+++ b/src/Adapter/Cache/MemcachedCache.php
@@ -109,9 +109,6 @@ class MemcachedCache extends BaseCacheHandler
         return $this->collection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     private function computeCacheKeys(array $keys): string
     {
         ksort($keys);

--- a/src/Adapter/Cache/Psr6Cache.php
+++ b/src/Adapter/Cache/Psr6Cache.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Cache\Adapter\Cache;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Sonata\Cache\CacheElement;
+use Sonata\Cache\CacheElementInterface;
+
+final class Psr6Cache extends BaseCacheHandler
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $psr6Pool;
+
+    public function __construct(CacheItemPoolInterface $psr6Pool)
+    {
+        $this->psr6Pool = $psr6Pool;
+    }
+
+    public function get(array $keys): CacheElementInterface
+    {
+        $psr6Item = $this->psr6Pool->getItem($this->computeCacheKey($keys));
+
+        return $this->handleGet($keys, $psr6Item->get());
+    }
+
+    public function has(array $keys): bool
+    {
+        return $this->psr6Pool->hasItem($this->computeCacheKey($keys));
+    }
+
+    public function set(array $keys, $value, int $ttl = CacheElement::DAY, array $contextualKeys = []): CacheElementInterface
+    {
+        $cacheElement = new CacheElement($keys, $value, $ttl);
+
+        $psr6Item = $this->psr6Pool->getItem($this->computeCacheKey($keys));
+        $psr6Item->set($cacheElement);
+        $psr6Item->expiresAfter($ttl);
+        $this->psr6Pool->save($psr6Item);
+
+        return $cacheElement;
+    }
+
+    public function flush(array $keys = []): bool
+    {
+        return $this->psr6Pool->deleteItem($this->computeCacheKey($keys));
+    }
+
+    public function flushAll(): bool
+    {
+        return $this->psr6Pool->clear();
+    }
+
+    public function isContextual(): bool
+    {
+        return false;
+    }
+
+    private function computeCacheKey(array $keys): string
+    {
+        ksort($keys);
+
+        return md5(serialize($keys));
+    }
+}

--- a/src/CacheElement.php
+++ b/src/CacheElement.php
@@ -92,7 +92,7 @@ final class CacheElement implements CacheElementInterface
      */
     public function isExpired(): bool
     {
-        return strtotime('now') > ($this->createdAt->format('U') + $this->ttl);
+        return strtotime('now') > ((int) ($this->createdAt->format('U')) + $this->ttl);
     }
 
     /**

--- a/tests/Adapter/Cache/BaseTest.php
+++ b/tests/Adapter/Cache/BaseTest.php
@@ -15,6 +15,7 @@ namespace Sonata\Cache\Tests\Adapter\Cache;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Cache\CacheAdapterInterface;
+use Sonata\Cache\CacheElement;
 
 abstract class BaseTest extends TestCase
 {
@@ -28,7 +29,7 @@ abstract class BaseTest extends TestCase
         // init cache
         $cache = $this->getCache();
         $cacheElement = $cache->set(['id' => 7], 'data');
-        static::assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        static::assertInstanceOf(CacheElement::class, $cacheElement);
         static::assertTrue($cache->has(['id' => 7]));
 
         // test flush
@@ -40,7 +41,7 @@ abstract class BaseTest extends TestCase
         static::assertFalse($cache->has(['id' => 42]));
 
         $cacheElement = $cache->get(['id' => 7]);
-        static::assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        static::assertInstanceOf(CacheElement::class, $cacheElement);
 
         // test flush all
         $res = $cache->flushAll();
@@ -54,7 +55,7 @@ abstract class BaseTest extends TestCase
 
         $cacheElement = $cache->get(['invalid']);
 
-        static::assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        static::assertInstanceOf(CacheElement::class, $cacheElement);
         static::assertTrue($cacheElement->isExpired());
     }
 
@@ -68,7 +69,7 @@ abstract class BaseTest extends TestCase
 
         $cacheElement = $cache->get(['mykey']);
 
-        static::assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        static::assertInstanceOf(CacheElement::class, $cacheElement);
         static::assertTrue($cacheElement->isExpired());
         static::assertNull($cacheElement->getData());
     }

--- a/tests/Adapter/Cache/Psr6CacheTest.php
+++ b/tests/Adapter/Cache/Psr6CacheTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Cache\Tests\Adapter\Cache;
+
+use Sonata\Cache\Adapter\Cache\Psr6Cache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class Psr6CacheTest extends BaseTest
+{
+    public function getCache()
+    {
+        return new Psr6Cache(new ArrayAdapter());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/cache/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/cache/issues/50

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/cache/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Psr6Cache` that allows using a PSR6 compliant cache implementation
```
Remaining questions
- should we deprecate all other cache adapters?
- what about `CounterAdapterInterface`? To me this does not even belong into this repository. Should we deprecate this fully? Or also add some PSR6 adapter for it? Where is this even used? 
- How exactly do we continue moving away from this repository on `BlockBundle` and `PageBundle`?
